### PR TITLE
フォーマット切替機能周りの調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Mac,Ubuntu,Windowsで動作確認済みです！
     ```bash
     poetry install
     ```
+   または
+   ```bash
+   make install
+   ```
     
 4. アプリケーションを起動します。
     
@@ -46,8 +50,12 @@ Mac,Ubuntu,Windowsで動作確認済みです！
 
 # CANViewerの機能
 
-- インターバル送信
-- 単発送信
+- 単発送信  
+  `Interval`に入力せずに`Start`ボタンを押す
+- インターバル送信  
+  `Interval`に入力して`Start`ボタンを押す
+- 標準フォーマットと拡張フォーマットの切り替え  
+   `StdID`と`ExtID`を押すと切り替え
 
 # **注意事項**
 
@@ -86,26 +94,34 @@ Operation confirmed on Mac, Ubuntu, and Windows!
 
 2. Change to the directory where the Python application is stored.
 
-```bash
-cd path/to/your/python/application
-```
+   ```bash
+   cd path/to/your/python/application
+   ```
 
 3. Use Poetry to resolve dependencies and create a virtual environment.
 
-```bash
-poetry install
-```
+   ```bash
+   poetry install
+   ```
+   or
+   ```bash
+   make install
+   ```
 
 4. Start the application.
 
-```bash
-make
-```
+   ```bash
+   make
+   ```
 
 # CANViewer features
 
-- Interval transmission
-- Single transmission
+- Single transmission  
+   Click `Start`button **without** any input in `Interval`field
+- Interval transmission  
+   Click `Start`button **with** some input in `Interval`field
+- Select ID format  
+   Click `StdID`button or `ExtID`button
 
 # **Notes**
 

--- a/main.py
+++ b/main.py
@@ -90,10 +90,11 @@ class MainWindow(QMainWindow):
 
         # データ入力
         data_layout = QHBoxLayout()
-        self.stdid_label = QLabel("StdID")
-        # ラベルをクリックしたら、StdIdからExtIdにトグル
-        self.stdid_label.mousePressEvent = lambda event: self.toggle_stdid_extid()
-        data_layout.addWidget(self.stdid_label)
+        self.id_button = QPushButton("StdID")
+        # ボタンをクリックしたら、StdIdからExtIdにトグル
+        self.id_button.setMinimumWidth(50)
+        self.id_button.clicked.connect(self.toggle_stdid_extid)
+        data_layout.addWidget(self.id_button)
         self.stdid_edit = QLineEdit("0")
         self.stdid_edit.setValidator(QIntValidator())
         data_layout.addWidget(self.stdid_edit)
@@ -227,11 +228,9 @@ class MainWindow(QMainWindow):
     def toggle_stdid_extid(self):
         self.is_extended_id = not self.is_extended_id  # モードを切り替え
         if self.is_extended_id:
-            self.stdid_label.setText("ExtID")
-            self.stdid_label.setStyleSheet("color: red")
+            self.id_button.setText("ExtID")
         else:
-            self.stdid_label.setText("StdID")
-            self.stdid_label.setStyleSheet("color: black")
+            self.id_button.setText("StdID")
 
     def send_data(self):
         sendable = True

--- a/main.py
+++ b/main.py
@@ -277,9 +277,13 @@ class MainWindow(QMainWindow):
                 else:
                     color: str = '#2C4AFF'  # blue
                 dir = 'TX'
+            if msg.is_extended_id:
+                id_str = f"{msg.arbitration_id:08x}"
+            else:
+                id_str = "_____" + f"{msg.arbitration_id:03x}"
             ms_timestamp = datetime.now().strftime("%M:%S:%f")[:-3]
             data_str = ' '.join(f"{byte:02x}" for byte in msg.data)
-            text = f"time:{ms_timestamp}\t{dir}:{'E' if msg.is_error_frame else ' '} {'EXT' if msg.is_extended_id else 'STD'}ID:{msg.arbitration_id:04x} data:{data_str}"
+            text = f"time:{ms_timestamp}\t{dir}:{'E' if msg.is_error_frame else ' '} {'EXT' if msg.is_extended_id else 'STD'}ID:{id_str} data:{data_str}"
             print(text)
             self.log(text, color=color)
 


### PR DESCRIPTION
- IDのフォーマット切り替えをボタンに変更
- フレーム表示におけるIDの桁表示を調整
16進表記で標準は最大3桁、拡張は最大8桁のため、標準の時に5桁分アンダーバーを挿入(スペース埋めができませんでした……)
- README.mdに使い方を追記