### PR TITLE
Specify hatch build targets for uv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,12 @@ name: Build and Release
 
 on:
   push:
+    branches:
+      - main
+      - develop
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -17,26 +21,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Install Poetry
-        run: pip install poetry
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
-        run: poetry install --no-root --no-ansi --no-interaction
-
-      - name: Install Nuitka
-        run: poetry run pip install nuitka
+        run: uv sync --no-dev
 
       - name: Build with Nuitka
         run: |
           mkdir -p dist
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            poetry run nuitka main.py --output-filename=CANViewer --onefile --standalone --follow-imports --windows-icon-from-ico=asset/icon.ico --enable-plugin=pyside6 --output-dir=dist  --include-module=can.interfaces.slcan --assume-yes-for-downloads --windows-disable-console --remove-output
+            uv run nuitka main.py --output-filename=CANViewer --onefile --standalone --follow-imports --windows-icon-from-ico=asset/icon.ico --enable-plugin=pyside6 --output-dir=dist  --include-module=can.interfaces.slcan --assume-yes-for-downloads --windows-disable-console --remove-output
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            poetry run nuitka main.py --output-filename=CANViewer --macos-create-app-bundle --standalone --follow-imports --macos-app-icon=asset/icon.icns --enable-plugin=pyside6 --output-dir=dist --include-module=can.interfaces.slcan --assume-yes-for-downloads --macos-app-name=CANViewer --macos-signed-app-name=CANViewer --macos-signed-app-name=com.tomixrm.CANViewer --remove-output
+            uv run nuitka main.py --output-filename=CANViewer --macos-create-app-bundle --standalone --follow-imports --macos-app-icon=asset/icon.icns --enable-plugin=pyside6 --output-dir=dist --include-module=can.interfaces.slcan --assume-yes-for-downloads --macos-app-name=CANViewer --macos-signed-app-name=CANViewer --macos-signed-app-name=com.tomixrm.CANViewer --remove-output
 
             mv dist/main.app dist/CANViewer.app
 
@@ -44,7 +45,7 @@ jobs:
 
             rm -rf dist/CANViewer.app
           else
-            poetry run nuitka main.py --output-filename=CANViewer --onefile --standalone --follow-imports --linux-icon=asset/icon.png --enable-plugin=pyside6 --output-dir=dist --include-module=can.interfaces.slcan --assume-yes-for-downloads --remove-output
+            uv run nuitka main.py --output-filename=CANViewer --onefile --standalone --follow-imports --linux-icon=asset/icon.png --enable-plugin=pyside6 --output-dir=dist --include-module=can.interfaces.slcan --assume-yes-for-downloads --remove-output
           fi
         shell: bash
 

--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,3 @@ cython_debug/
 #.idea/
 
 
-
-# poetry
-poetry.lock

--- a/README.jp.md
+++ b/README.jp.md
@@ -47,8 +47,8 @@ Pythonベースで書かれているためMac,Ubuntu,Windows動作します(Sock
 
 - CANデバイスが用意されていること(SLCANであれば[CANable2.0](https://canable.io)や[MKS CANable](https://ja.aliexpress.com/item/1005003746105255.html)など)
 - Pythonがインストールされていること
-  - [Poetry](https://python-poetry.org)がインストールされていない場合は、事前にインストールする必要があります。(ライブラリのバージョン管理で使います)
-  - Poetryを使用して依存関係を解決することで、Pythonアプリケーションの実行に必要なパッケージが自動的にインストールされます。
+  - [uv](https://docs.astral.sh/uv/)がインストールされていない場合は、事前にインストールする必要があります。(例えば `pip install uv` )。ライブラリの依存関係管理に使用します。
+  - uvを使用して依存関係を解決することで、Pythonアプリケーションの実行に必要なパッケージが自動的にインストールされます。
 - `make`が入っていると便利です
 
 ## ビルド方法
@@ -60,10 +60,10 @@ Pythonベースで書かれているためMac,Ubuntu,Windows動作します(Sock
     cd CANViewerのディレクトリ
     ```
 
-3. Poetryを使用して依存関係を解決し、仮想環境を作成します。
+3. uvを使用して依存関係を解決し、仮想環境を作成します。
 
     ``` bash
-    poetry install
+    uv sync
     ```
 
    または
@@ -75,7 +75,7 @@ Pythonベースで書かれているためMac,Ubuntu,Windows動作します(Sock
 4. アプリケーションを起動します。
 
     ``` bash
-    poetry run python main.py
+    uv run python main.py
     ```
 
     または
@@ -87,8 +87,13 @@ Pythonベースで書かれているためMac,Ubuntu,Windows動作します(Sock
 5. SocketCANで動作させる場合のオプション
 
    ``` bash
-   poetry run python main.py -c socketcan
+   uv run python main.py -c socketcan
    ```
+
+## GitHub Actionsビルドの確認
+
+GitHub ActionsのワークフローはWindows、macOS、Ubuntu向けに配布物をビルドします。
+タグを切らなくても、Actionsタブの「Build and Release」から手動トリガーしてビルド手順を確認できます。
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ You can download a pre-built application from [Releases](https://github.com/Tomi
 
 - CAN device must be available (for SLCAN, [CANable2.0](https://canable.io) or [MKS CANable](https://ja.aliexpress.com/item/1005003746105255.html))
 - Python must be installed.
-  - If [Poetry](https://python-poetry.org) is not installed, it must be installed beforehand. (It is used for version control of libraries)
-  - Resolving dependencies using Poetry will automatically install the packages needed to run your Python application.
+  - If [uv](https://docs.astral.sh/uv/) is not installed, it must be installed beforehand (for example, with `pip install uv`). It is used for dependency management.
+  - Resolving dependencies using uv will automatically install the packages needed to run your Python application.
 - It is useful to have `make` included!
 
 ## How to build
@@ -64,10 +64,10 @@ You can download a pre-built application from [Releases](https://github.com/Tomi
     cd CANViewer-directory
     ```
 
-3. Use Poetry to resolve dependencies and create virtual environments.
+3. Use uv to resolve dependencies and create virtual environments.
 
     ``` bash
-    poetry install
+    uv sync
     ```
 
    or
@@ -79,8 +79,8 @@ You can download a pre-built application from [Releases](https://github.com/Tomi
 4. Launch the application with command.
 
     ``` bash
-    poetry run python main.py
-    ```
+   uv run python main.py
+   ```
 
     or
 
@@ -91,8 +91,13 @@ You can download a pre-built application from [Releases](https://github.com/Tomi
 5. Options for operating with SocketCAN
 
    ``` bash
-   poetry run python main.py -c socketcan
+   uv run python main.py -c socketcan
    ```
+
+## Checking GitHub Actions builds
+
+The GitHub Actions workflow builds distributables for Windows, macOS, and Ubuntu.
+You can manually trigger the workflow from the **Actions** tab (look for "Build and Release") to confirm that the build steps are working without creating a tag.
 
 ## LICENSE
 

--- a/makefile
+++ b/makefile
@@ -1,17 +1,19 @@
-.PHONY: run run-socketcan clean install format
+.PHONY: run run-socketcan clean install format analyze
+
 run:
-	poetry run python main.py
+uv run python main.py
 
 run-socketcan:
-	poetry run python main.py -c socketcan
+uv run python main.py -c socketcan
+
 clean:
-	rm -rf __pycache__ .mypy_cache poetry.lock
+rm -rf __pycache__ .mypy_cache .venv
 
 install:
-	poetry install
+uv sync
 
 format:
-	poetry run black .
+uv run black .
 
 analyze:
-	poetry run mypy .
+uv run mypy .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,33 @@
-[tool.poetry]
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
 name = "canviewer"
 version = "0.0.1"
 description = "CAN Sender GUI with slcand"
-authors = ["tomixrm <chocolate0785lego@icloud.com>"]
-license = "LGPL-2.1"
+authors = [{ name = "tomixrm", email = "chocolate0785lego@icloud.com" }]
 readme = "README.md"
+license = { text = "LGPL-2.1" }
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "pyserial>=3.5,<4.0",
+    "python-can==4.5.0",
+    "pyside6>=6.8.2.1,<6.9",
+    "nuitka>=2.4.11,<3.0",
+    "returns>=0.24.0,<0.25",
+]
 
-[tool.poetry.dependencies]
-python = "^3.10"
-pyserial = "^3.5"
-python-can = "4.5.0"
-argparse = "^1.4.0"
-pyside6 = {version = "^6.8.2.1", python = ">=3.10,<3.14"}
-nuitka = "^2.4.11"
-black = "^25.1.0"
-mypy = "^1.15.0"
-returns = "^0.24.0"
+[tool.uv]
 
+[dependency-groups]
+dev = [
+    "black>=25.1.0,<26.0",
+    "mypy>=1.15.0,<2.0",
+]
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src", "main.py", "README.md", "README.jp.md", "asset/**/*"]


### PR DESCRIPTION
## Summary
- configure hatch wheel target to package the existing `src` module layout
- include application entry script and assets in the source distribution to support builds

## Testing
- `uv build --wheel --sdist` *(fails in CI-like environment without internet access to fetch hatchling)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69253c86d4e88320a16d9c4086271102)