### PR TITLE
Feature/canfd

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -1,7 +1,7 @@
 <div align="center">
     <img src="/asset/icon.png" alt="CANVIEWER LOGO" width="120" />
     <h1>CANViewer</h1>
-    <p>cross-platform CAN bus monitor, built on Python.</p>
+    <p>Cross-platform CAN bus monitor built with Python.</p>
 
   [![License](https://img.shields.io/github/license/TomiXRM/CANViewer)](https://github.com/TomiXRM/CANViewer/blob/main/LICENSE)
   [![GitHub stars](https://img.shields.io/github/stars/TomiXRM/CANViewer)](https://github.com/TomiXRM/CANViewer/stargazers)
@@ -13,7 +13,7 @@
 
 このアプリケーションは、SLCANやSocketCANデバイスをPCに接続し、PCから手軽にCAN通信を検証できるツールです。
 CANバス上に流れるデータの受信、定期送信や単発送信、標準IDと拡張IDの切り替え、10進数↔️16進数変換に対応しています。
-Pythonベースで書かれているためMac,Ubuntu,Windows動作します(SocketCANはUbuntuのみ対応)
+Pythonベースで書かれているため、Mac、Ubuntu、Windowsで動作します（SocketCANはUbuntuのみ対応）。
 
 ## App Downloads
 
@@ -22,9 +22,9 @@ Pythonベースで書かれているためMac,Ubuntu,Windows動作します(Sock
 ## CANViewerの機能
 
 - **単発送信** : `Interval`に入力せずに`Start`ボタンを押す
-- **インターバル送信** : `Interval`にインターバル送信したい間隔(ミリ秒)を入力して`Start`ボタンを押す
+- **インターバル送信** : `Interval`にインターバル送信したい間隔（ミリ秒）を入力して`Start`ボタンを押す
 - **標準/拡張フォーマットの切り替え** : `StdID`/`ExtID`のクリックでフォーマットの切り替え
-- **入力進数変更** : `DataFrame`のラベルをクリックすることで切り替え可能。また`Ctrl+H(J)`でHEX、`Ctrl+D(F)`でDECへの入力メソッド切り替えが可能
+- **入力進数の変更** : `DataFrame`のラベルをクリックすることで切り替え可能。また`Ctrl+H(J)`でHEX、`Ctrl+D(F)`でDECへの入力方法の切り替えが可能
 - **フィルタ機能** : `Ctrl+P`でProモードに切り替わります。Proモードではフィルタ設定用のテーブルが表示され、無視したいIDを入力することで、指定したIDのメッセージがログから非表示になります。(現在Proモードはフィルタ機能のみ実装されています)
 
 ### インターバル送信
@@ -41,7 +41,7 @@ Pythonベースで書かれているためMac,Ubuntu,Windows動作します(Sock
 
 ### 無視したいIDのフィルタ機能
 
-![filter.gi](asset/filter.gif)
+![filter.gif](./asset/filter.gif)
 
 ## Development Prerequisites / 開発に必要なもの
 
@@ -49,7 +49,7 @@ Pythonベースで書かれているためMac,Ubuntu,Windows動作します(Sock
 - Pythonがインストールされていること
   - [Poetry](https://python-poetry.org)がインストールされていない場合は、事前にインストールする必要があります。(ライブラリのバージョン管理で使います)
   - Poetryを使用して依存関係を解決することで、Pythonアプリケーションの実行に必要なパッケージが自動的にインストールされます。
-- `make`が入っていると便利です
+- `make`がインストールされていると便利です
 
 ## ビルド方法
 
@@ -92,4 +92,4 @@ Pythonベースで書かれているためMac,Ubuntu,Windows動作します(Sock
 
 ## ライセンス
 
-このプロジェクトはLGPLライセンスです。 詳しくは[LICENSE](LICENSE)を確認ください
+このプロジェクトはLGPLライセンスです。詳しくは[LICENSE](LICENSE)を確認ください

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
     <img src="/asset/icon.png" alt="CANVIEWER LOGO" width="120" />
     <h1>CANViewer</h1>
-    <p>cross-platform CAN bus monitor, built on Python.</p>
+    <p>Cross-platform CAN bus monitor built with Python.</p>
 
   [![License](https://img.shields.io/github/license/TomiXRM/CANViewer)](https://github.com/TomiXRM/CANViewer/blob/main/LICENSE)
   [![GitHub stars](https://img.shields.io/github/stars/TomiXRM/CANViewer)](https://github.com/TomiXRM/CANViewer/stargazers)
@@ -25,9 +25,9 @@ You can download a pre-built application from [Releases](https://github.com/Tomi
 
 ## CANViewer Features
 
-- **Single-shot transmission** : press `Start` button without entering `Interval
-- **Interval transmission** : Input the interval (in milliseconds) you want to transmit interval in `Interval` and press `Start` button.
-- **Switch standard/extended format** : Click `StdID`/`ExtID` to switch format
+- **Single-shot transmission** : press `Start` button without entering `Interval`.
+- **Interval transmission** : Enter the interval (milliseconds) in `Interval` and press `Start` button.
+- **Switch standard/extended format** : Click `StdID`/`ExtID` to switch format.
 - **Change input decimal number** : Click `DataFrame` label to switch. Also, you can switch input method to HEX by `Ctrl+H(J)` and to DEC by `Ctrl+D(F)`.
 - **Filter function** : `Ctrl+P` switches to Pro mode; in Pro mode, a table for filter settings is displayed, and by entering an ID to be ignored, messages with the specified ID are hidden from the log. (Currently, only the filter function is implemented in Pro mode.)
 
@@ -43,9 +43,9 @@ You can download a pre-built application from [Releases](https://github.com/Tomi
 
 ![hex_dec_switch.gif](./asset/hex_dec_switch.gif)
 
-### filter function for IDs you want to ignore
+### Filter function for IDs you want to ignore
 
-![filter.gi](asset/filter.gif)
+![filter.gif](./asset/filter.gif)
 
 ## Development Prerequisites / What you need for development
 
@@ -53,7 +53,7 @@ You can download a pre-built application from [Releases](https://github.com/Tomi
 - Python must be installed.
   - If [Poetry](https://python-poetry.org) is not installed, it must be installed beforehand. (It is used for version control of libraries)
   - Resolving dependencies using Poetry will automatically install the packages needed to run your Python application.
-- It is useful to have `make` included!
+- It is useful to have `make` installed!
 
 ## How to build
 

--- a/main.py
+++ b/main.py
@@ -35,8 +35,9 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.radix_type = initial_radix_type
         self.can_type = can_type
+        self.can_fd_enabled = False
 
-        self.setWindowTitle(f"CANViewer | {self.can_type} | {self.radix_type}")
+        self._update_window_title()
         self.setGeometry(500, 200, 800, 300)
 
         self._central_widget = QWidget()
@@ -141,6 +142,7 @@ class MainWindow(QMainWindow):
         self.channel_selector.channel_signal.connect(
             self._toggle_can_interface_connection
         )
+        self.channel_selector.mode_signal.connect(self._on_can_mode_changed)
 
         ###############################################
         # Handle Log data from 'can_message_editor'
@@ -189,14 +191,19 @@ class MainWindow(QMainWindow):
     def log(self, text: str, color: Optional[str] = None) -> None:
         self.log_signal.emit(text, color)
 
-    @Slot(str)
-    def _toggle_can_interface_connection(self, channel: str) -> None:
+    @Slot(str, bool)
+    def _toggle_can_interface_connection(self, channel: str, can_fd: bool) -> None:
         # check CAN-BUS-Interface connection status
         if self.can_handler.get_connect_status() == False:
+            self.can_fd_enabled = can_fd
+            self.can_message_editor.set_can_fd_mode(self.can_fd_enabled)
+            self._update_window_title()
             # Get Baudrate from 'baudrate_selector'
             bps: int = self.baudrate_selector.get_baudrate()
             # Make a connection
-            rslt = self.can_handler.connect_device(channel, bps, self.can_type)
+            rslt = self.can_handler.connect_device(
+                channel, bps, self.can_type, self.can_fd_enabled
+            )
 
             if is_successful(rslt):
                 # set statuses
@@ -206,7 +213,7 @@ class MainWindow(QMainWindow):
                 self.log(f"Connected to {channel} : {bps} bps", color="green")
             else:
                 self.log(f"{rslt.failure()}", color="red")
-            
+
         else:
             self.can_handler.disconnect_devive()
             # set statuses
@@ -234,14 +241,26 @@ class MainWindow(QMainWindow):
     @Slot()
     def _change_radix_to_dec(self) -> None:
         self.radix_type = "dec"
-        self.setWindowTitle(f"CANViewer | {self.can_type} | {self.radix_type}")
+        self._update_window_title()
         self.radix_status_signal.emit(self.radix_type)
 
     @Slot()
     def _change_radix_to_hex(self) -> None:
         self.radix_type = "hex"
-        self.setWindowTitle(f"CANViewer | {self.can_type} | {self.radix_type}")
+        self._update_window_title()
         self.radix_status_signal.emit(self.radix_type)
+
+    @Slot(bool)
+    def _on_can_mode_changed(self, can_fd: bool) -> None:
+        self.can_fd_enabled = can_fd
+        self.can_message_editor.set_can_fd_mode(self.can_fd_enabled)
+        self._update_window_title()
+
+    def _update_window_title(self) -> None:
+        can_mode = "CAN-FD" if self.can_fd_enabled else "CAN"
+        self.setWindowTitle(
+            f"CANViewer | {self.can_type} | {can_mode} | {self.radix_type}"
+        )
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "canviewer"
-version = "0.0.1"
+version = "0.0.9"
 description = "CAN Sender GUI with slcand"
 authors = ["tomixrm <chocolate0785lego@icloud.com>"]
 license = "LGPL-2.1"
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 pyserial = "^3.5"
-python-can = "4.5.0"
+python-can = "4.6.1"
 argparse = "^1.4.0"
 pyside6 = {version = "^6.8.2.1", python = ">=3.10,<3.14"}
 nuitka = "^2.4.11"

--- a/src/component/can_message_editor.py
+++ b/src/component/can_message_editor.py
@@ -1,9 +1,16 @@
 from typing import Optional, Tuple, Union
 
 import can
-from PySide6.QtCore import Signal, Slot
-from PySide6.QtGui import QIntValidator
-from PySide6.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QPushButton, QWidget
+from PySide6.QtCore import Signal, Slot, Qt
+from PySide6.QtWidgets import (
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ..utils.validator import Validator
 
@@ -16,6 +23,9 @@ class CanMessageEditor(QWidget):
         super().__init__(parent)
         self.is_extended_id = False  # Default: Standard ID
         self.radix_type = initial_radix_type
+        self.can_fd_enabled = False
+        self._row_size = 8
+        self._max_data_bytes = 8
 
         # color style
         self.style_edit_default = ""
@@ -25,32 +35,58 @@ class CanMessageEditor(QWidget):
         # main layout
         self._layout = QHBoxLayout()
         self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(4)
         self.setLayout(self._layout)
+
+        self._left_container = QWidget()
+        self._grid_layout = QGridLayout()
+        self._grid_layout.setContentsMargins(0, 0, 0, 0)
+        self._grid_layout.setHorizontalSpacing(4)
+        self._grid_layout.setVerticalSpacing(2)
+        self._left_container.setLayout(self._grid_layout)
+        self._layout.addWidget(self._left_container)
+        self._layout.setAlignment(self._left_container, Qt.AlignTop)
 
         # ID (StdID/ExtID)
         self.id_button = QPushButton("StdID")
         self.id_button.setMinimumWidth(50)
         self.id_button.clicked.connect(self.toggle_stdid_extid)
-        self._layout.addWidget(self.id_button)
+        self._grid_layout.addWidget(self.id_button, 0, 0, Qt.AlignBottom)
 
         # ID (Edit)
         self.id_edit = QLineEdit("0")
-        self.id_edit.setValidator(QIntValidator())
-        self._layout.addWidget(self.id_edit)
+        self.id_edit.setValidator(Validator.dec_validator)
+        self._grid_layout.addWidget(self.id_edit, 0, 1, Qt.AlignBottom)
 
         # Label for DataFrame
         self.dataframe_label = QLabel("DataFrame")
         self.dataframe_label.mousePressEvent = lambda event: self._toggle_radix()
-        self._layout.addWidget(self.dataframe_label)
+        self.dataframe_label.setFixedHeight(self.id_edit.sizeHint().height())
+        self.dataframe_label.setAlignment(Qt.AlignVCenter)
+        self._grid_layout.addWidget(self.dataframe_label, 0, 2, Qt.AlignBottom)
 
-        # DataFrame (Edit)
+        self._dataframe_button_layout = QVBoxLayout()
+        self._dataframe_button_layout.setContentsMargins(0, 0, 0, 0)
+        self._dataframe_button_layout.setSpacing(2)
+
+        self.dataframe_add_button = QPushButton("Add 8")
+        self.dataframe_add_button.setObjectName("dataframe-list-add")
+        self.dataframe_add_button.clicked.connect(self._on_add_dataframe_row_clicked)
+        self._dataframe_button_layout.addWidget(self.dataframe_add_button)
+
+        self.dataframe_remove_button = QPushButton("Remove 8")
+        self.dataframe_remove_button.setObjectName("dataframe-list-remove")
+        self.dataframe_remove_button.clicked.connect(
+            self._on_remove_dataframe_row_clicked
+        )
+        self._dataframe_button_layout.addWidget(self.dataframe_remove_button)
+        self._layout.addLayout(self._dataframe_button_layout)
+        self._layout.setAlignment(self._dataframe_button_layout, Qt.AlignTop)
+
         self.dataframe_edits = []
-        for i in range(8):
-            edit = QLineEdit("0")
-            edit.setContentsMargins(0, 0, 0, 0)
-            edit.setValidator(QIntValidator())
-            self.dataframe_edits.append(edit)
-            self._layout.addWidget(edit)
+        self._dataframe_rows = []
+        self._add_dataframe_row()
+        self._update_add_button_state()
 
     @Slot(str)
     def update_radix(self, new_radix: str) -> None:
@@ -87,6 +123,7 @@ class CanMessageEditor(QWidget):
                 edit.setText(
                     Validator.text_hexadecimalize_from_decimal_text(edit.text())
                 )
+        self._update_add_button_state()
 
     @Slot()
     def toggle_stdid_extid(self) -> None:
@@ -99,7 +136,6 @@ class CanMessageEditor(QWidget):
     # returns message and usable(True/False)
     def get_message(self) -> Tuple[Union[can.Message, None], bool]:
         dataframe = []
-        dlc = 8
 
         # ID
         id_text = self.id_edit.text()
@@ -111,26 +147,37 @@ class CanMessageEditor(QWidget):
         # TODO: Validate id_value with maximam number(StdID and ExtID)
 
         # data frame
-        for n, data_edit in enumerate(self.dataframe_edits):
-            data_text: str = data_edit.text()
-            if data_text:
-                value = Validator.decimalize(data_text, self.radix_type)
-                value = max(0, min(value, 255))
+        if self.can_fd_enabled:
+            for data_edit in self.dataframe_edits:
+                data_text: str = data_edit.text()
+                if data_text:
+                    value = Validator.decimalize(data_text, self.radix_type)
+                    value = max(0, min(value, 255))
+                else:
+                    value = 0
                 dataframe.append(value)
-            else:
-                dlc = n
-                break
+        else:
+            for data_edit in self.dataframe_edits:
+                data_text: str = data_edit.text()
+                if data_text:
+                    value = Validator.decimalize(data_text, self.radix_type)
+                    value = max(0, min(value, 255))
+                    dataframe.append(value)
+                else:
+                    break
 
         if not dataframe:
             print("DataFrame is empty.")
             self._log("DataFrame is empty.", "red")
             return None, False  # msg , usable
+        dlc = len(dataframe)
 
         msg = can.Message(
             arbitration_id=id_value,
             data=dataframe,
             dlc=dlc,
             is_extended_id=self.is_extended_id,
+            is_fd=self.can_fd_enabled,
             is_rx=False,
         )
 
@@ -142,3 +189,80 @@ class CanMessageEditor(QWidget):
 
     def _log(self, text: str, color: Optional[str] = None) -> None:
         self.log_signal.emit(text, color)
+
+    def set_can_fd_mode(self, enabled: bool) -> None:
+        if self.can_fd_enabled == enabled:
+            return
+        self.can_fd_enabled = enabled
+        self._max_data_bytes = 64 if enabled else 8
+        if not enabled:
+            self._trim_dataframe_rows(8)
+        self._update_add_button_state()
+
+    def _update_add_button_state(self) -> None:
+        if not hasattr(self, "dataframe_add_button"):
+            return
+        can_add = (
+            self.can_fd_enabled and len(self.dataframe_edits) < self._max_data_bytes
+        )
+        can_remove = self.can_fd_enabled and len(self.dataframe_edits) > self._row_size
+        self.dataframe_add_button.setVisible(self.can_fd_enabled)
+        self.dataframe_add_button.setEnabled(can_add)
+        self.dataframe_remove_button.setVisible(can_remove)
+        self.dataframe_remove_button.setEnabled(can_remove)
+
+    def _create_data_edit(self) -> QLineEdit:
+        edit = QLineEdit("0")
+        edit.setContentsMargins(0, 0, 0, 0)
+        if self.radix_type == "hex":
+            edit.setStyleSheet(self.style_edit_hex)
+            edit.setValidator(Validator.hex_validator)
+        else:
+            edit.setStyleSheet(self.style_edit_default)
+            edit.setValidator(Validator.dec_validator)
+        return edit
+
+    def _add_dataframe_row(self) -> None:
+        if len(self.dataframe_edits) >= self._max_data_bytes:
+            return
+        row_layout = QHBoxLayout()
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        row_layout.setSpacing(2)
+        row_edits = []
+        for _ in range(self._row_size):
+            if len(self.dataframe_edits) >= self._max_data_bytes:
+                break
+            edit = self._create_data_edit()
+            row_edits.append(edit)
+            self.dataframe_edits.append(edit)
+            row_layout.addWidget(edit)
+        self._grid_layout.addLayout(
+            row_layout,
+            len(self._dataframe_rows),
+            3,
+            1,
+            1,
+            Qt.AlignLeft | Qt.AlignBottom,
+        )
+        self._dataframe_rows.append((row_layout, row_edits))
+        self._update_add_button_state()
+
+    def _trim_dataframe_rows(self, target_total: int) -> None:
+        while len(self.dataframe_edits) > target_total and self._dataframe_rows:
+            row_layout, row_edits = self._dataframe_rows.pop()
+            self._grid_layout.removeItem(row_layout)
+            for edit in row_edits:
+                self.dataframe_edits.remove(edit)
+                edit.setParent(None)
+                edit.deleteLater()
+            row_layout.setParent(None)
+        self._update_add_button_state()
+
+    @Slot()
+    def _on_add_dataframe_row_clicked(self) -> None:
+        self._add_dataframe_row()
+
+    @Slot()
+    def _on_remove_dataframe_row_clicked(self) -> None:
+        target_total = max(self._row_size, len(self.dataframe_edits) - self._row_size)
+        self._trim_dataframe_rows(target_total)

--- a/src/component/channel_selector.py
+++ b/src/component/channel_selector.py
@@ -7,7 +7,8 @@ from serial.tools.list_ports import comports
 
 class ChannelSelector(QWidget):
 
-    channel_signal = Signal(str)
+    channel_signal = Signal(str, bool)
+    mode_signal = Signal(bool)
 
     def __init__(self, parent=None, can_type="slcan"):
         super().__init__(parent)
@@ -24,6 +25,11 @@ class ChannelSelector(QWidget):
         self._list_layout.addWidget(QLabel("Port"))
         self._channel_combobox = QComboBox()
         self._list_layout.addWidget(self._channel_combobox)
+        self._list_layout.addWidget(QLabel("Mode"))
+        self._mode_combobox = QComboBox()
+        self._mode_combobox.addItems(["CAN", "CAN-FD"])
+        self._mode_combobox.currentIndexChanged.connect(self._emit_mode_changed)
+        self._list_layout.addWidget(self._mode_combobox)
         self._list_layout.setContentsMargins(0, 0, 0, 0)
         self._layout.addLayout(self._list_layout)
 
@@ -38,6 +44,7 @@ class ChannelSelector(QWidget):
         self._layout.addWidget(self._refresh_button)
 
         self._refresh()
+        self._emit_mode_changed()
 
     @Slot(bool)
     def can_connection_change_callback(self, connected: bool) -> None:
@@ -48,9 +55,15 @@ class ChannelSelector(QWidget):
 
     def connection_complete(self) -> None:
         self._connect_button.setText("Disconnect")
+        self._channel_combobox.setEnabled(False)
+        self._refresh_button.setEnabled(False)
+        self._mode_combobox.setEnabled(False)
 
     def disconnection_complete(self) -> None:
         self._connect_button.setText("Connect")
+        self._channel_combobox.setEnabled(True)
+        self._refresh_button.setEnabled(True)
+        self._mode_combobox.setEnabled(True)
 
     @Slot()
     def _refresh(self) -> None:
@@ -61,7 +74,7 @@ class ChannelSelector(QWidget):
                 print(f" {n}: {port:20} {desc} {devid}")
                 self._channel_combobox.addItem(port)
                 # set CANable device as default
-                if "CAN" in desc: 
+                if "CAN" in desc:
                     self._channel_combobox.setCurrentText(port)
 
         elif self._can_type == "socketcan":
@@ -87,4 +100,12 @@ class ChannelSelector(QWidget):
 
     @Slot()
     def _on_connect_button_clicked(self) -> None:
-        self.channel_signal.emit(self._channel_combobox.currentText())
+        self.channel_signal.emit(
+            self._channel_combobox.currentText(), self._is_can_fd()
+        )
+
+    def _is_can_fd(self) -> bool:
+        return self._mode_combobox.currentText() == "CAN-FD"
+
+    def _emit_mode_changed(self) -> None:
+        self.mode_signal.emit(self._is_can_fd())

--- a/src/component/logbox.py
+++ b/src/component/logbox.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import can
 from PySide6.QtCore import Slot
-from PySide6.QtGui import QFont
+from PySide6.QtGui import QFont, QTextCursor
 from PySide6.QtWidgets import QTextEdit
 
 
@@ -17,11 +17,20 @@ class LogBox(QTextEdit):
     # show log to logbox
     @Slot(str, str)
     def log(self, text: str, color: Optional[str] = None) -> None:
-
         if color is None:
-            self.append(text)
+            if "<font" in text or "<span" in text:
+                self._append_html(text)
+            else:
+                self.append(text)
         else:
-            self.append(f"<font color='{color}'>{text}</font>")
+            self._append_html(f"<font color='{color}'>{text}</font>")
+
+    def _append_html(self, html: str) -> None:
+        cursor = self.textCursor()
+        cursor.movePosition(QTextCursor.End)
+        cursor.insertHtml(html)
+        cursor.insertBlock()
+        self.setTextCursor(cursor)
 
     # show can message to logbox
     @Slot(can.Message)
@@ -54,6 +63,60 @@ class LogBox(QTextEdit):
             id_str = "_____" + f"{msg.arbitration_id:03x}"
 
         ms_timestamp = datetime.now().strftime("%M:%S:%f")[:-3]
-        data_str = " ".join(f"{byte:02x}".upper() for byte in msg.data)
-        text = f"time:{ms_timestamp}\t{dir}:{'E' if msg.is_error_frame else ' '} {'EXT' if msg.is_extended_id else 'STD'}ID:{id_str.upper()} data:{data_str}"
-        self.log(text, color=color)
+        data_bytes = list(msg.data) if msg.data is not None else []
+        if msg.is_fd and len(data_bytes) > 8:
+            data_html = self._format_fd_data_with_gradient(
+                data_bytes, is_tx=not msg.is_rx
+            )
+            prefix = (
+                f"time:{ms_timestamp}\t{dir}:{'E' if msg.is_error_frame else ' '} "
+                f"{'EXT' if msg.is_extended_id else 'STD'}ID:{id_str.upper()} data:"
+            )
+            text = f"<font color='{color}'>{prefix}</font> {data_html}"
+            self.log(text)
+        else:
+            data_str = " ".join(f"{byte:02x}".upper() for byte in data_bytes)
+            text = f"time:{ms_timestamp}\t{dir}:{'E' if msg.is_error_frame else ' '} {'EXT' if msg.is_extended_id else 'STD'}ID:{id_str.upper()} data:{data_str}"
+            self.log(text, color=color)
+
+    def _format_fd_data_with_gradient(self, data_bytes: list[int], is_tx: bool) -> str:
+        if is_tx:
+            start_color = "#2C4AFF"
+            end_color = "#FF00FF"
+        else:
+            start_color = "#EC4954"
+            end_color = "#FFA22B"
+        chunks = [data_bytes[i : i + 8] for i in range(0, len(data_bytes), 8)]
+        steps = max(2, min(8, len(chunks)))
+        colors = self._interpolate_colors(start_color, end_color, steps)
+        segments = []
+        for idx, chunk in enumerate(chunks):
+            color = colors[min(idx, len(colors) - 1)]
+            segment = " ".join(f"{byte:02x}".upper() for byte in chunk)
+            segments.append(f"<font color='{color}'>{segment}</font>")
+        return " | ".join(segments)
+
+    def _interpolate_colors(
+        self, start_hex: str, end_hex: str, steps: int
+    ) -> list[str]:
+        def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+            hex_color = hex_color.lstrip("#")
+            return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+
+        def rgb_to_hex(rgb: tuple[int, int, int]) -> str:
+            return "#{:02X}{:02X}{:02X}".format(*rgb)
+
+        start = hex_to_rgb(start_hex)
+        end = hex_to_rgb(end_hex)
+        if steps <= 1:
+            return [rgb_to_hex(start)]
+        colors = []
+        for i in range(steps):
+            t = i / (steps - 1)
+            rgb = (
+                round(start[0] + (end[0] - start[0]) * t),
+                round(start[1] + (end[1] - start[1]) * t),
+                round(start[2] + (end[2] - start[2]) * t),
+            )
+            colors.append(rgb_to_hex(rgb))
+        return colors

--- a/src/utils/can_handler.py
+++ b/src/utils/can_handler.py
@@ -1,6 +1,7 @@
 import can
 from PySide6.QtCore import QThread, Signal, Slot
-from returns.result import Result,Success,Failure 
+from returns.result import Result, Success, Failure
+
 
 class CANHandler(QThread):
     send_can_signal = Signal(can.Message)
@@ -11,14 +12,19 @@ class CANHandler(QThread):
         self.can_bus = None
         self.can_notifier = None
 
-    def connect_device(self, channel: str, bps: int, interface: str) -> Result[bool,Exception]:
+    def connect_device(
+        self, channel: str, bps: int, interface: str, can_fd: bool
+    ) -> Result[bool, Exception]:
         try:
-            self.can_bus = can.interface.Bus(
+            bus_kwargs = dict(
                 channel=channel,
                 bitrate=bps,
                 receive_own_messages=False,
                 interface=interface,
             )
+            if can_fd and interface == "socketcan":
+                bus_kwargs["fd"] = True
+            self.can_bus = can.interface.Bus(**bus_kwargs)
             self.can_notifier = can.Notifier(self.can_bus, [self._on_can_recieve])
             return Success(True)
         except Exception as e:


### PR DESCRIPTION
## 概要
- CAN/CAN-FD 切り替えUIを追加し、接続/送信に反映
- CAN-FD用のデータ入力（8バイト単位で最大64、追加/削除）を実装
- CAN-FDログを8バイト区切り（|）＋グラデーション表示に対応
- python-can を 4.6.1 に更新

 ## 画面/挙動
- CAN-FD選択時のみ「Add 8 / Remove 8」が有効
- ログは8バイトごとに区切り、TXは青→マゼンタ、RXは赤→オレンジ

## 備考
- SocketCANはCAN-FD時に `fd=True` で接続
- 送信メッセージは `is_fd` を正しく設定

## テスト
  - 未実施（UI手動確認のみ）
