### PR TITLE
[codex] Enable manual build workflow dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -57,6 +58,7 @@ jobs:
 
   release:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` to the existing build workflow so it can be run manually from GitHub Actions.
- Guard the release job with `startsWith(github.ref, 'refs/tags/v')` so manual runs build and upload artifacts without creating a GitHub Release.

## Impact

This makes it possible to test the current build workflow from the Actions UI before cutting a tag. Tag pushes still build and publish releases as before.

## Validation

- Inspected the workflow diff; this PR only changes the dispatch trigger and release guard.