### PR TITLE
[codex] Unify CAN channel selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ class MainWindow(QMainWindow):
 
         # Components
         self.can_handler = CANHandler()
-        self.channel_selector = ChannelSelector(can_type=self.can_type)
+        self.channel_selector = ChannelSelector(preferred_interface=self.can_type)
         self.can_message_editor = CanMessageEditor()
         self.baudrate_selector = BaudrateSelector()
         self.communication_controller = CommunicationController()
@@ -260,11 +260,15 @@ def main():
     )
 
     parser.add_argument(
-        "-c", "--can", type=str, default="slcan", help="CAN type (gs_usb, slcan)"
+        "-c",
+        "--can",
+        type=str,
+        default="slcan",
+        help="Preferred CAN interface (slcan, gs_usb, socketcan)",
     )
     args = parser.parse_args()
 
-    print("CAN Type:", args.can)
+    print("Preferred CAN interface:", args.can)
     app = QApplication(sys.argv)
     window = MainWindow(args.can, "dec")
     window.show()

--- a/scripts/build_nuitka.py
+++ b/scripts/build_nuitka.py
@@ -57,6 +57,7 @@ def nuitka_base_command(output_dir: Path) -> list[str]:
         "--enable-plugin=pyside6",
         "--include-module=can.interfaces.slcan",
         "--include-module=can.interfaces.gs_usb",
+        "--include-module=can.interfaces.socketcan",
         "--include-package=gs_usb",
         "--include-package=usb",
         "--assume-yes-for-downloads",

--- a/src/component/channel_selector.py
+++ b/src/component/channel_selector.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from PySide6.QtCore import Signal, Slot
@@ -13,29 +15,118 @@ else:
     GsUsb = _GsUsb
 
 
+@dataclass(frozen=True)
+class CanChannel:
+    interface: str
+    channel: str | int
+    label: str
+
+
+SLCAN_EXCLUDED_KEYWORDS = (
+    "BLUETOOTH",
+    "DEBUG-CONSOLE",
+)
+
+SLCAN_INCLUDED_KEYWORDS = (
+    "CAN",
+    "USB2CAN",
+    "CANABLE",
+    "CANDLELIGHT",
+)
+
+
+def _get_gs_usb_device_label(index: int, device: Any) -> str:
+    usb_device = getattr(device, "usb_device", None) or getattr(device, "gs_usb", None)
+    manufacturer = getattr(usb_device, "manufacturer", None)
+    product = getattr(usb_device, "product", None)
+    serial_number = getattr(device, "serial_number", None)
+    description = " ".join(
+        str(value) for value in [manufacturer, product, serial_number] if value
+    )
+    return f"{index}: {description}" if description else str(index)
+
+
+def _is_slcan_candidate(port_info: Any) -> bool:
+    text = f"{port_info.device} {port_info.description} {port_info.hwid}".upper()
+    if any(keyword in text for keyword in SLCAN_EXCLUDED_KEYWORDS):
+        return False
+    return any(keyword in text for keyword in SLCAN_INCLUDED_KEYWORDS)
+
+
+def _discover_slcan_channels() -> list[CanChannel]:
+    channels: list[CanChannel] = []
+    port_infos = sorted(
+        (port_info for port_info in comports() if _is_slcan_candidate(port_info)),
+        key=lambda port_info: (
+            "CAN" not in f"{port_info.description} {port_info.hwid}".upper(),
+            port_info.device,
+        ),
+    )
+    for port_info in port_infos:
+        port = port_info.device
+        desc = port_info.description
+        label = f"SLCAN - {port}"
+        if desc:
+            label = f"{label} ({desc})"
+        channels.append(CanChannel(interface="slcan", channel=port, label=label))
+    return channels
+
+
+def _discover_gs_usb_channels() -> list[CanChannel]:
+    if GsUsb is None:
+        print("gs_usb is not installed")
+        return []
+
+    channels: list[CanChannel] = []
+    try:
+        devices = GsUsb.scan()
+    except Exception as error:
+        print(f"gs_usb scan failed: {error}")
+        return []
+
+    for index, device in enumerate(devices):
+        device_label = _get_gs_usb_device_label(index, device)
+        channels.append(
+            CanChannel(
+                interface="gs_usb",
+                channel=index,
+                label=f"gs_usb - {device_label}",
+            )
+        )
+    return channels
+
+
+def _discover_socketcan_channels() -> list[CanChannel]:
+    net_dir = Path("/sys/class/net")
+    if not net_dir.exists():
+        return []
+
+    channels: list[CanChannel] = []
+    for net_device in sorted(net_dir.iterdir()):
+        name = net_device.name
+        if name.startswith(("can", "vcan")):
+            channels.append(
+                CanChannel(
+                    interface="socketcan",
+                    channel=name,
+                    label=f"SocketCAN - {name}",
+                )
+            )
+    return channels
+
+
 class ChannelSelector(QWidget):
     channel_signal = Signal(str, str)
 
-    def __init__(self, parent=None, can_type="slcan"):
+    def __init__(self, parent=None, preferred_interface="slcan"):
         super().__init__(parent)
 
-        self._can_type = can_type  # "slcan" or "gs_usb"
+        self._preferred_interface = preferred_interface
 
         # main layout
         self._layout = QHBoxLayout()
         self._layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(self._layout)
-
-        # CAN interface selector
-        self._can_type_combobox = QComboBox()
-        self._can_type_combobox.addItem("SLCAN", "slcan")
-        self._can_type_combobox.addItem("gs_usb", "gs_usb")
-        self._can_type_combobox.setFixedWidth(90)
-        current_index = self._can_type_combobox.findData(self._can_type)
-        if current_index >= 0:
-            self._can_type_combobox.setCurrentIndex(current_index)
-        self._can_type_combobox.currentIndexChanged.connect(self._on_can_type_changed)
-        self._layout.addWidget(self._can_type_combobox)
 
         # Channel selection list layout
         self._list_layout = QHBoxLayout()
@@ -66,45 +157,35 @@ class ChannelSelector(QWidget):
 
     def connection_complete(self) -> None:
         self._connect_button.setText("Disconnect")
-        self._can_type_combobox.setEnabled(False)
+        self._channel_combobox.setEnabled(False)
+        self._refresh_button.setEnabled(False)
 
     def disconnection_complete(self) -> None:
         self._connect_button.setText("Connect")
-        self._can_type_combobox.setEnabled(True)
+        self._channel_combobox.setEnabled(True)
+        self._refresh_button.setEnabled(True)
         self._update_connect_button_enabled()
 
     @Slot()
     def _refresh(self) -> None:
         self._channel_combobox.clear()
-        if self._can_type == "slcan":
-            # List available ports
-            for n, port_info in enumerate(sorted(comports()), 1):
-                port = port_info.device
-                desc = port_info.description
-                devid = port_info.hwid
-                print(f" {n}: {port:20} {desc} {devid}")
-                self._channel_combobox.addItem(port)
-                # set CANable device as default
-                if "CAN" in desc:
-                    self._channel_combobox.setCurrentText(port)
+        channels = [
+            *_discover_slcan_channels(),
+            *_discover_gs_usb_channels(),
+            *_discover_socketcan_channels(),
+        ]
+        preferred_index = -1
+        for index, channel in enumerate(channels):
+            print(f" {index}: {channel.label}")
+            self._channel_combobox.addItem(channel.label, channel)
+            if (
+                preferred_index < 0
+                and channel.interface == self._preferred_interface
+            ):
+                preferred_index = index
 
-        elif self._can_type == "gs_usb":
-            if GsUsb is None:
-                print("gs_usb is not installed")
-                return
-
-            # List available gs_usb devices by index.
-            for index, device in enumerate(GsUsb.scan()):
-                product = getattr(device.usb_device, "product", None)
-                manufacturer = getattr(device.usb_device, "manufacturer", None)
-                description = " ".join(
-                    value for value in [manufacturer, product] if value
-                )
-                label = f"{index}: {description}" if description else str(index)
-                print(f" {index}: {label}")
-                self._channel_combobox.addItem(label, index)
-        else:
-            print("Invalid CAN type")
+        if preferred_index >= 0:
+            self._channel_combobox.setCurrentIndex(preferred_index)
 
         self._update_connect_button_enabled()
 
@@ -116,19 +197,8 @@ class ChannelSelector(QWidget):
         self._connect_button.setEnabled(self._channel_combobox.count() > 0)
 
     @Slot()
-    def _on_can_type_changed(self) -> None:
-        can_type = self._can_type_combobox.currentData()
-        if not isinstance(can_type, str):
-            return
-
-        self._can_type = can_type
-        self._refresh()
-
-    @Slot()
     def _on_connect_button_clicked(self) -> None:
-        channel = self._channel_combobox.currentData()
-        if channel is None:
-            channel = self._channel_combobox.currentText()
-        if str(channel) == "":
+        selected = self._channel_combobox.currentData()
+        if not isinstance(selected, CanChannel):
             return
-        self.channel_signal.emit(str(channel), self._can_type)
+        self.channel_signal.emit(str(selected.channel), selected.interface)

--- a/src/utils/can_handler.py
+++ b/src/utils/can_handler.py
@@ -1,6 +1,58 @@
+import gc
+import logging
+import traceback
+
 import can
+import usb.core
+from gs_usb.gs_usb import GsUsb
 from PySide6.QtCore import QThread, Signal, Slot
 from returns.result import Result, Success, Failure
+
+
+def _format_connection_error(error: Exception, interface: str) -> Exception:
+    if (
+        interface == "gs_usb"
+        and isinstance(error, usb.core.USBError)
+        and getattr(error, "errno", None) == 13
+    ):
+        return PermissionError(
+            "Access denied opening gs_usb device. On macOS, grant libusb access "
+            "by running CANViewer with sufficient USB permissions, for example "
+            "`sudo uv run main.py -c gs_usb`, then reconnect the adapter if needed."
+        )
+    return error
+
+
+def _check_gs_usb_access(index: int) -> None:
+    devs = GsUsb.scan()
+    if len(devs) <= index:
+        raise ValueError(f"Cannot find gs_usb device {index}. Devices found: {len(devs)}")
+    _ = devs[index].device_capability
+
+
+def _create_can_bus(
+    channel: str | int, bitrate: int, interface: str
+) -> can.BusABC:
+    can_bus_logger = logging.getLogger("can.bus")
+    previous_disabled = can_bus_logger.disabled
+    if interface == "gs_usb":
+        can_bus_logger.disabled = True
+
+    try:
+        return can.interface.Bus(
+            channel=channel,
+            bitrate=bitrate,
+            receive_own_messages=False,
+            interface=interface,
+        )
+    except Exception as error:
+        if interface == "gs_usb":
+            traceback.clear_frames(error.__traceback__)
+            error.__traceback__ = None
+            gc.collect()
+        raise error from None
+    finally:
+        can_bus_logger.disabled = previous_disabled
 
 
 class CANHandler(QThread):
@@ -22,16 +74,13 @@ class CANHandler(QThread):
             bus_channel: str | int = channel
             if interface == "gs_usb":
                 bus_channel = int(channel)
+                _check_gs_usb_access(bus_channel)
 
-            self.can_bus = can.interface.Bus(
-                channel=bus_channel,
-                bitrate=bps,
-                receive_own_messages=False,
-                interface=interface,
-            )
+            self.can_bus = _create_can_bus(bus_channel, bps, interface)
             self.can_notifier = can.Notifier(self.can_bus, [self._on_can_recieve])
             return Success(True)
         except Exception as e:
+            e = _format_connection_error(e, interface)
             print(e)
             self.can_bus = None
             return Failure(e)


### PR DESCRIPTION
## Summary

- Replace the separate CAN interface selector with a unified port selector that lists SLCAN, gs_usb, and SocketCAN channels together.
- Store each combo-box item as a structured `CanChannel` so connection still passes the correct `channel` and `interface` to `CANHandler`.
- Filter noisy macOS serial ports such as Bluetooth and debug-console from SLCAN candidates.
- Improve gs_usb device labeling and permission-error handling, including suppressing the misleading python-can shutdown warning after failed gs_usb initialization.
- Include `can.interfaces.socketcan` in Nuitka builds.

## Why

The UI should present the actual CAN connection target instead of making users choose an interface type first. This also makes room for SocketCAN without adding another top-level selector.

## Validation

- `uv run ruff check main.py src/component/channel_selector.py src/utils/can_handler.py scripts/build_nuitka.py`
- Qt offscreen smoke checks for `ChannelSelector` and `MainWindow`
- Local SLCAN discovery now hides Bluetooth/debug-console ports while keeping the USB2CAN port visible