### PR TITLE
gs_usbの実装に基づくエラーフレーム表示の対応

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,6 +127,7 @@ class MainWindow(QMainWindow):
         # Send CAN-BUS Message to logbox
         self.can_log_signal.connect(self.log_box.can_msg_log)
         self.can_handler.send_can_signal.connect(self.log_box.can_msg_log)
+        self.can_handler.error_log_signal.connect(self.log)
 
         # Notify the CAN-BUS connection status
         self.can_connection_status_signal.connect(

--- a/src/component/can_message_editor.py
+++ b/src/component/can_message_editor.py
@@ -1,7 +1,7 @@
 from typing import Optional, Tuple, Union
 
 import can
-from PySide6.QtCore import Signal, Slot, Qt
+from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtGui import QIntValidator, QMouseEvent
 from PySide6.QtWidgets import (
     QGridLayout,
@@ -54,18 +54,22 @@ class CanMessageEditor(QWidget):
         self._grid_layout.setVerticalSpacing(2)
         self._left_container.setLayout(self._grid_layout)
         self._layout.addWidget(self._left_container)
-        self._layout.setAlignment(self._left_container, Qt.AlignmentFlag.AlignTop)
+        self._layout.setAlignment(
+            self._left_container, Qt.AlignmentFlag.AlignTop)
 
         # ID (StdID/ExtID)
         self.id_button = QPushButton("StdID")
         self.id_button.setMinimumWidth(50)
         self.id_button.clicked.connect(self.toggle_stdid_extid)
-        self._grid_layout.addWidget(self.id_button, 0, 0, Qt.AlignmentFlag.AlignBottom)
+        self._grid_layout.addWidget(
+            self.id_button, 0, 0, Qt.AlignmentFlag.AlignBottom)
 
         # ID (Edit)
         self.id_edit = QLineEdit("0")
         self.id_edit.setValidator(QIntValidator())
-        self._grid_layout.addWidget(self.id_edit, 0, 1, Qt.AlignmentFlag.AlignBottom)
+        self.id_edit.setMinimumWidth(50)
+        self._grid_layout.addWidget(
+            self.id_edit, 0, 1, Qt.AlignmentFlag.AlignBottom)
 
         # Label for DataFrame
         self.dataframe_label = ClickableLabel("DataFrame")
@@ -81,7 +85,8 @@ class CanMessageEditor(QWidget):
         self._dataframe_button_layout.setSpacing(2)
 
         self.dataframe_add_button = QPushButton("Add 8")
-        self.dataframe_add_button.clicked.connect(self._on_add_dataframe_row_clicked)
+        self.dataframe_add_button.clicked.connect(
+            self._on_add_dataframe_row_clicked)
         self._dataframe_button_layout.addWidget(self.dataframe_add_button)
 
         self.dataframe_remove_button = QPushButton("Remove 8")
@@ -119,21 +124,24 @@ class CanMessageEditor(QWidget):
             for edit in self.dataframe_edits:
                 edit.setStyleSheet(self.style_edit_default)
                 edit.setValidator(Validator.dec_validator)
-                edit.setText(Validator.text_decimalize_from_hex_text(edit.text()))
+                edit.setText(
+                    Validator.text_decimalize_from_hex_text(edit.text()))
 
         elif new_radix == "hex":
             # ID Edit
             self.id_edit.setStyleSheet(self.style_edit_hex)
             self.id_edit.setValidator(Validator.hex_validator)
             self.id_edit.setText(
-                Validator.text_hexadecimalize_from_decimal_text(self.id_edit.text())
+                Validator.text_hexadecimalize_from_decimal_text(
+                    self.id_edit.text())
             )
             # DataFrame Edits
             for edit in self.dataframe_edits:
                 edit.setStyleSheet(self.style_edit_hex)
                 edit.setValidator(Validator.hex_validator)
                 edit.setText(
-                    Validator.text_hexadecimalize_from_decimal_text(edit.text())
+                    Validator.text_hexadecimalize_from_decimal_text(
+                        edit.text())
                 )
         self._update_dataframe_button_state()
 
@@ -172,7 +180,8 @@ class CanMessageEditor(QWidget):
             for data_edit in self.dataframe_edits:
                 can_data_text: str = data_edit.text()
                 if can_data_text:
-                    value = Validator.decimalize(can_data_text, self.radix_type)
+                    value = Validator.decimalize(
+                        can_data_text, self.radix_type)
                     value = max(0, min(value, 255))
                     dataframe.append(value)
                 else:
@@ -214,9 +223,11 @@ class CanMessageEditor(QWidget):
 
     def _update_dataframe_button_state(self) -> None:
         can_add = (
-            self.can_fd_enabled and len(self.dataframe_edits) < self._max_data_bytes
+            self.can_fd_enabled and len(
+                self.dataframe_edits) < self._max_data_bytes
         )
-        can_remove = self.can_fd_enabled and len(self.dataframe_edits) > self._row_size
+        can_remove = self.can_fd_enabled and len(
+            self.dataframe_edits) > self._row_size
         self.dataframe_add_button.setVisible(self.can_fd_enabled)
         self.dataframe_add_button.setEnabled(can_add)
         self.dataframe_remove_button.setVisible(can_remove)
@@ -277,5 +288,6 @@ class CanMessageEditor(QWidget):
 
     @Slot()
     def _on_remove_dataframe_row_clicked(self) -> None:
-        target_total = max(self._row_size, len(self.dataframe_edits) - self._row_size)
+        target_total = max(self._row_size, len(
+            self.dataframe_edits) - self._row_size)
         self._trim_dataframe_rows(target_total)

--- a/src/component/channel_selector.py
+++ b/src/component/channel_selector.py
@@ -36,10 +36,18 @@ SLCAN_INCLUDED_KEYWORDS = (
 
 
 def _get_gs_usb_device_label(index: int, device: Any) -> str:
+    def read_usb_attribute(target: Any, attribute: str) -> Any:
+        if target is None:
+            return None
+        try:
+            return getattr(target, attribute, None)
+        except Exception:
+            return None
+
     usb_device = getattr(device, "usb_device", None) or getattr(device, "gs_usb", None)
-    manufacturer = getattr(usb_device, "manufacturer", None)
-    product = getattr(usb_device, "product", None)
-    serial_number = getattr(device, "serial_number", None)
+    manufacturer = read_usb_attribute(usb_device, "manufacturer")
+    product = read_usb_attribute(usb_device, "product")
+    serial_number = read_usb_attribute(device, "serial_number")
     description = " ".join(
         str(value) for value in [manufacturer, product, serial_number] if value
     )

--- a/src/utils/can_handler.py
+++ b/src/utils/can_handler.py
@@ -6,7 +6,31 @@ import can
 import usb.core  # type: ignore[import-untyped]
 from gs_usb.gs_usb import GsUsb  # type: ignore[import-untyped]
 from PySide6.QtCore import QThread, Signal, Slot
-from returns.result import Result, Success, Failure
+from returns.result import Failure, Result, Success
+
+# CAN error bit definitions based on Linux SocketCAN error frames
+# source : https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/can/error.h
+CAN_ERR_TX_TIMEOUT = 0x00000001
+CAN_ERR_LOSTARB = 0x00000002
+CAN_ERR_CRTL = 0x00000004
+CAN_ERR_PROT = 0x00000008
+CAN_ERR_TRX = 0x00000010
+CAN_ERR_ACK = 0x00000020
+CAN_ERR_BUSOFF = 0x00000040
+CAN_ERR_BUSERROR = 0x00000080
+CAN_ERR_RESTARTED = 0x00000100
+
+CAN_ERROR_CLASSES = (
+    (CAN_ERR_TX_TIMEOUT, "TX timeout"),
+    (CAN_ERR_LOSTARB, "lost arbitration"),
+    (CAN_ERR_CRTL, "controller problem"),
+    (CAN_ERR_PROT, "protocol violation"),
+    (CAN_ERR_TRX, "transceiver status"),
+    (CAN_ERR_ACK, "ACK error"),
+    (CAN_ERR_BUSOFF, "bus off"),
+    (CAN_ERR_BUSERROR, "bus error"),
+    (CAN_ERR_RESTARTED, "controller restarted"),
+)
 
 
 def _format_connection_error(error: Exception, interface: str) -> Exception:
@@ -94,12 +118,39 @@ def _create_can_bus(
         can_bus_logger.disabled = previous_disabled
 
 
+def _format_can_error_frame(msg: can.Message) -> str:
+    error_classes = [
+        label
+        for error_bit, label in CAN_ERROR_CLASSES
+        if msg.arbitration_id & error_bit
+    ]
+    error_text = ", ".join(
+        error_classes) if error_classes else "unknown CAN error"
+    details = [f"CAN error frame: {error_text}"]
+
+    data = list(msg.data) if msg.data is not None else []
+    if msg.arbitration_id & CAN_ERR_ACK:
+        details.append(
+            "no other CAN node acknowledged the transmitted frame; "
+            "check bus wiring, termination, bitrate, peer power, and listen-only peers"
+        )
+    if msg.arbitration_id & CAN_ERR_BUSOFF:
+        details.append("controller entered bus-off state")
+    if len(data) >= 8 and (msg.arbitration_id & CAN_ERR_CRTL):
+        details.append(
+            f"tx error counter={data[6]}, rx error counter={data[7]}")
+
+    return ". ".join(details)
+
+
 class CANHandler(QThread):
     send_can_signal = Signal(can.Message)
+    error_log_signal = Signal(str, str)
 
     def __init__(self):
         super().__init__()
         self.ignore_ids = []
+        self._reported_error_frames: set[tuple[int, tuple[int, ...]]] = set()
         self.can_bus: can.BusABC | None = None
         self.can_notifier: can.Notifier | None = None
 
@@ -115,7 +166,8 @@ class CANHandler(QThread):
             if channel == "":
                 raise ValueError("No CAN channel is selected")
             if can_fd and interface == "gs_usb":
-                raise ValueError("CAN-FD is not supported for gs_usb channels yet")
+                raise ValueError(
+                    "CAN-FD is not supported for gs_usb channels yet")
 
             bus_channel: str | int = channel
             if interface == "gs_usb":
@@ -125,7 +177,9 @@ class CANHandler(QThread):
             self.can_bus = _create_can_bus(
                 bus_channel, bitrate, interface, can_fd, data_bitrate
             )
-            self.can_notifier = can.Notifier(self.can_bus, [self._on_can_recieve])
+            self._reported_error_frames.clear()
+            self.can_notifier = can.Notifier(
+                self.can_bus, [self._on_can_recieve])
             return Success(True)
         except Exception as e:
             e = _format_connection_error(e, interface)
@@ -140,6 +194,7 @@ class CANHandler(QThread):
             self.can_bus.shutdown()
         self.can_notifier = None
         self.can_bus = None
+        self._reported_error_frames.clear()
 
     def get_connect_status(self) -> bool:
         if self.can_bus is None:
@@ -155,6 +210,14 @@ class CANHandler(QThread):
 
     def _on_can_recieve(self, msg: can.Message) -> None:
         msg.is_rx = True
+        if msg.is_error_frame:
+            data = list(msg.data) if msg.data is not None else []
+            detail_without_counters = tuple(data[:6])
+            error_key = (msg.arbitration_id, detail_without_counters)
+            if error_key not in self._reported_error_frames:
+                self._reported_error_frames.add(error_key)
+                self.error_log_signal.emit(_format_can_error_frame(msg), "red")
+            return
         if msg.arbitration_id in self.ignore_ids:
             return
         self.send_can_signal.emit(msg)


### PR DESCRIPTION
socketcan, gs_usbを使用するを使用するとエラーフレームが発生したときに無限にログをエラーフレームで埋め尽くす実装になっていたので、gs_usbの実装をもとにエラー表示を適切に表示するように変更した